### PR TITLE
Update upstream.

### DIFF
--- a/v8pp/CMakeLists.txt
+++ b/v8pp/CMakeLists.txt
@@ -54,14 +54,20 @@ if(MSVC)
 	list(APPEND V8PP_COMPILE_OPTIONS /wd4190)
 	# set warning level 3 for system headers
 	list(APPEND V8PP_COMPILE_OPTIONS /experimental:external /external:anglebrackets /external:W3)
+	set(V8PP_COMPILE_OPTIONS_PUBLIC)
 else()
-	set(V8PP_COMPILE_OPTIONS -fno-rtti -fexceptions -Wall -Wextra -Wpedantic)
+	set(V8PP_COMPILE_OPTIONS -Wall -Wextra -Wpedantic)
+	if(APPLE)
+		set(V8PP_COMPILE_OPTIONS_PUBLIC -fno-rtti -fexceptions)
+	else()
+		list(APPEND V8PP_COMPILE_OPTIONS -fno-rtti -fexceptions)
+	endif()
 endif()
 
 if(V8PP_HEADER_ONLY)
 	add_library(v8pp INTERFACE)
 	target_compile_definitions(v8pp INTERFACE ${V8PP_DEFINES})
-	target_compile_options(v8pp INTERFACE ${V8PP_COMPILE_OPTIONS})
+	target_compile_options(v8pp INTERFACE ${V8PP_COMPILE_OPTIONS} ${V8PP_COMPILE_OPTIONS_PUBLIC})
 	target_include_directories(v8pp INTERFACE
 		$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
 		$<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
@@ -70,7 +76,8 @@ if(V8PP_HEADER_ONLY)
 else()
 	add_library(v8pp ${V8PP_HEADERS} ${V8PP_SOURCES})
 	target_compile_definitions(v8pp PUBLIC ${V8PP_DEFINES})
-	target_compile_options(v8pp PUBLIC ${V8PP_COMPILE_OPTIONS})
+	target_compile_options(v8pp PRIVATE ${V8PP_COMPILE_OPTIONS})
+	target_compile_options(v8pp PUBLIC ${V8PP_COMPILE_OPTIONS_PUBLIC})
 	target_include_directories(v8pp PUBLIC
 		$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
 		$<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>


### PR DESCRIPTION
to keep warning options only specific for v8pp, and
do not affect other porjects linked against v8pp.

See issue #176